### PR TITLE
[SQUASH] base: Introduce GamesPropsUtils[1/2]

### DIFF
--- a/core/java/android/app/Instrumentation.java
+++ b/core/java/android/app/Instrumentation.java
@@ -56,6 +56,7 @@ import android.view.Window;
 import android.view.WindowManagerGlobal;
 
 import com.android.internal.content.ReferrerIntent;
+import com.android.internal.util.custom.GamesPropsUtils;
 
 import java.io.File;
 import java.lang.annotation.Retention;
@@ -1246,6 +1247,7 @@ public class Instrumentation {
         app.attach(context);
         String packageName = context.getPackageName();
         PixelPropsUtils.setProps(packageName);
+        GamesPropsUtils.setProps(context);
         return app;
     }
     
@@ -1265,6 +1267,7 @@ public class Instrumentation {
         app.attach(context);
         String packageName = context.getPackageName();
         PixelPropsUtils.setProps(packageName);
+        GamesPropsUtils.setProps(context);
         return app;
     }
 

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -11487,6 +11487,13 @@ public final class Settings {
 
 
         /**
+         * Whether to spoof device as a high-end model to unlock higher FPS in certain games.
+         * @hide
+         */
+        @Readable
+        public static final String GAMES_DEVICE_SPOOF = "games_device_spoof";
+
+        /**
          * These entries are considered common between the personal and the managed profile,
          * since the managed profile doesn't get to change them.
          */

--- a/core/java/com/android/internal/util/custom/GamesPropsUtils.java
+++ b/core/java/com/android/internal/util/custom/GamesPropsUtils.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.util.custom;
+
+import android.content.Context;
+import android.os.Build;
+import android.os.SystemProperties;
+import android.util.Log;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GamesPropsUtils {
+
+    private static final String TAG = GamesPropsUtils.class.getSimpleName();
+    private static final boolean DEBUG = false;
+
+    private static final Map<String, Object> propsToChangeBS4 = createMap("2SM-X706B", "blackshark");
+    private static final String[] packagesToChangeBS4 = { // spoof as Black Shark 4
+            "com.proximabeta.mf.uamo"
+    };
+
+    private static final Map<String, Object> propsToChangeMI11TP = createMap("2107113SI", "Xiaomi");
+    private static final String[] packagesToChangeMI11TP = { // spoof as Mi 11T PRO
+            "com.ea.gp.apexlegendsmobilefps",
+            "com.levelinfinite.hotta.gp",
+            "com.supercell.clashofclans",
+            "com.vng.mlbbvn",
+            "com.mobile.legends"
+    };
+
+    private static final Map<String, Object> propsToChangeMI13P = createMap("2210132C", "Xiaomi");
+    private static final String[] packagesToChangeMI13P = { // spoof as Mi 13 PRO
+            "com.levelinfinite.sgameGlobal",
+            "com.tencent.tmgp.sgame"
+    };
+
+    private static final Map<String, Object> propsToChangeOP8P = createMap("IN2020", "OnePlus");
+    private static final String[] packagesToChangeOP8P = { // spoof as OnePlus 8 PRO
+            "com.netease.lztgglobal",
+            "com.pubg.imobile",
+            "com.pubg.krmobile",
+            "com.rekoo.pubgm",
+            "com.riotgames.league.wildrift",
+            "com.riotgames.league.wildrifttw",
+            "com.riotgames.league.wildriftvn",
+            "com.tencent.ig",
+            "com.tencent.tmgp.pubgmhd",
+            "com.vng.pubgmobile"
+    };
+
+    private static final Map<String, Object> propsToChangeOP9P = createMap("LE2101", "OnePlus");
+    private static final String[] packagesToChangeOP9P = { // spoof as OnePlus 9 PRO
+            "com.epicgames.fortnite",
+            "com.epicgames.portal",
+            "com.tencent.lolm"
+    };
+
+    private static final Map<String, Object> propsToChangeF5 = createMap("23049PCD8G", "Xiaomi");
+    private static final String[] packagesToChangeF5 = { // spoof as POCO F5
+            "com.dts.freefiremax",
+            "com.dts.freefireth"
+    };
+
+    private static final Map<String, Object> propsToChangeROG6 = createMap("ASUS_AI2201", "asus");
+    private static final String[] packagesToChangeROG6 = { // spoof as ROG Phone 6
+            "com.activision.callofduty.shooter",
+    	    "com.ea.gp.fifamobile",
+            "com.gameloft.android.ANMP.GloftA9HM",
+            "com.madfingergames.legends",
+            "com.pearlabyss.blackdesertm",
+            "com.pearlabyss.blackdesertm.gl"
+    };
+
+    private static final Map<String, Object> propsToChangeXP5 = createMap("SO-52A", "Sony");
+    private static final String[] packagesToChangeXP5 = { // spoof as Xperia 5
+            "com.garena.game.codm",
+            "com.tencent.tmgp.kr.codm",
+            "com.vng.codmvn"
+    };
+
+    private static Map<String, Object> createMap(String model, String manufacturer) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("MODEL", model);
+        map.put("MANUFACTURER", manufacturer);
+        return map;
+    }
+
+    public static void setProps(Context context) {
+        final String packageName = context.getPackageName();
+
+        if (packageName == null || packageName.isEmpty()) {
+            return;
+        }
+        Map<String, Object> propsToChange = null;
+        if (!SystemProperties.getBoolean("persist.sys.pixelprops.games", false)) {
+            return;
+        } else {
+            if (Arrays.asList(packagesToChangeBS4).contains(packageName)) {
+                propsToChange = propsToChangeBS4;
+            } else if (Arrays.asList(packagesToChangeMI11TP).contains(packageName)) {
+                propsToChange = propsToChangeMI11TP;
+            } else if (Arrays.asList(packagesToChangeMI13P).contains(packageName)) {
+                propsToChange = propsToChangeMI13P;
+            } else if (Arrays.asList(packagesToChangeOP8P).contains(packageName)) {
+                propsToChange = propsToChangeOP8P;
+            } else if (Arrays.asList(packagesToChangeOP9P).contains(packageName)) {
+                propsToChange = propsToChangeOP9P;
+            } else if (Arrays.asList(packagesToChangeF5).contains(packageName)) {
+                propsToChange = propsToChangeF5;
+            } else if (Arrays.asList(packagesToChangeROG6).contains(packageName)) {
+                propsToChange = propsToChangeROG6;
+            } else if (Arrays.asList(packagesToChangeXP5).contains(packageName)) {
+                propsToChange = propsToChangeXP5;
+            }
+        }
+        if (propsToChange != null) {
+            dlog("Defining props for: " + packageName);
+            for (Map.Entry<String, Object> prop : propsToChange.entrySet()) {
+                String key = prop.getKey();
+                Object value = prop.getValue();
+                setPropValue(key, value);
+            }
+        }
+    }
+
+    private static void setPropValue(String key, Object value) {
+        try {
+            dlog("Defining prop " + key + " to " + value.toString());
+            Field field = Build.class.getDeclaredField(key);
+            field.setAccessible(true);
+            field.set(null, value);
+            field.setAccessible(false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Log.e(TAG, "Failed to set prop " + key, e);
+        }
+    }
+
+    public static void dlog(String msg) {
+        if (DEBUG) Log.d(TAG, msg);
+    }
+}

--- a/core/java/com/android/internal/util/custom/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/custom/PixelPropsUtils.java
@@ -368,7 +368,7 @@ public class PixelPropsUtils {
         }
     }
 
-    private static void setPropValue(String key, Object value) {
+    static void setPropValue(String key, Object value) {
         try {
             if (DEBUG) Log.d(TAG, "Defining prop " + key + " to " + value.toString());
             Field field = Build.class.getDeclaredField(key);


### PR DESCRIPTION
Rewritten from scratch, with settings toggle
Based on the following commits:

commit e2ebc7e0d3e74bff76f1cdc56e958c1f07fd4c0b
Author: rdkng1 <richardraya39@gmail.com>
Date:   Sat Dec 11 05:17:22 2021 +0000

    PixelPropsUtils: Add GamesProps

      Based on PixelPropsUtils, GamesProps will spoof the device needed to unlock the FPS of the following games:
      * Free Fire - Spoof Asus ROG Phone 1 will unlock 90 FPS
      * COD Mobile - Spoof Xperia 5 || will unlock 120 FPS (only on multiplayer mode)
      * PUBG Mobile - Spoof OnePlus 8 Pro will unlock 90 FPS
      * Wild Rift - Spoof OnePlus 8 Pro will unlock 120 FPS
      * Cyber Hunter - Spoof OnePlus 8 Pro will unlock 90 FPS
      * Fortnite - Spoof OnePlus 8 Pro will unlock 90 FPS

    @ neobuddy89: Adapt GamesProps to existing PixelProps and update games list.

commit ce68c443c392c9be6fd0591958db960a1f10f9e3
Author: Pranav Vashi <neobuddy89@gmail.com>
Date:   Sat Mar 26 12:32:23 2022 +0530

    PixelPropsUtils: Add game props for mobile legends

commit e819f8fb14924c32abce93cccc14fd9ea69b032b
Author: Joey Huab <joey@evolution-x.org>
Date:   Mon Aug 15 18:23:48 2022 +0000

    PixelPropsUtils: Update game props

    * Removed new state as multiple crash reports.

commit 328b97baa8039e4b127585ac467846faf5f13cb9
Author: johnmart19 <johnivan19999@gmail.com>
Date:   Mon Jul 11 01:37:47 2022 +0300

    PixelPropsUtils: GameProps: Hide Apex Legends as Mi11

    Change-Id: I80b0136ef75f61154011ed7831994ffe8b5f5c96

GamesPropsUtils: Add Gameprops for Battlegrounds Mobile India (BGMI)
* OP8P spoofing is no longer working
* Hence spoofing bgmi with Redmi K30 Ultra, which unlocks Smooth-Extreme to HDR-Extreme



GamesPropsUtils: Switch back BGMI to OnePlus 8 Pro
* After BGMI v2.7.0 update 90fps is now back so spoofing back to OP8P to gain 90fps in smooth settings






Change-Id: I9a56c2cb0ef6fbf52fb1f091face573d3120846c